### PR TITLE
Fixed spacing on firefox

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,11 @@ W skład koła wchodzą sekcje:
 
 ![Hackerman meme](assets/pics/hackerman_meme.jpg){width="500", align=right}
 
-- <h3>Analiza</h3>
-- [<h3>Crypto</h3>](crypto/crypto_wiki.md)
-- [<h3>Forensics</h3>](forensics/forensics_wiki.md)
-- [<h3>OSINT</h3>](osint/osint_wiki.md)
-- [<h3>Reverse</h3>](reverse/reverse_wiki.md)
-- [<h3>Web</h3>](web/web_wiki.md)
+- Analiza
+- [Crypto](crypto/crypto_wiki.md)
+- [Forensics](forensics/forensics_wiki.md)
+- [OSINT](osint/osint_wiki.md)
+- [Reverse](reverse/reverse_wiki.md)
+- [Web](web/web_wiki.md)
 
 <center><h2>Owocnego hackowania!</h2></center>


### PR DESCRIPTION
Instead of

![image](https://github.com/user-attachments/assets/6d616e52-604e-4759-a7d0-b42b9943e475)

we now get:

![image](https://github.com/user-attachments/assets/e2bf1e9c-f517-47be-a66d-2393d4763c71)