### PR TITLE
Add private metadata viewer to OSINT tools

### DIFF
--- a/docs/osint/sources/sources_wiki.md
+++ b/docs/osint/sources/sources_wiki.md
@@ -63,6 +63,7 @@ Do tego dorzucić mozna wszelkie media społecznościowe (SOCMINT), scrapery czy
     - [BeenVerified](https://www.beenverified.com) (nie działa w UE)
 - Analiza plików
     - [Metadata2go](https://www.metadata2go.com)
+    - [Metadata Remover](https://metadataremover.ai/metadata-viewer) — lokalna przeglądarka metadanych EXIF, GPS, XMP i IPTC działająca w przeglądarce bez przesyłania plików
     - [Fotoforensics](https://fotoforensics.com) oraz [29a.ch](https://29a.ch/sandbox/2012/imageerrorlevelanalysis/)
     - [Stolencamerafinder](https://www.stolencamerafinder.com)
 - Generatory


### PR DESCRIPTION
Disclosure: I maintain [Metadata Remover](https://metadataremover.ai/metadata-viewer).

This adds one browser-local metadata viewer in the existing "Analiza plików" tool list. The tool reads supported EXIF, GPS, XMP, and IPTC fields from JPG, PNG, and WebP files without uploading them. This directly complements the page's warning about sharing files with online services.